### PR TITLE
ROADMAP 2.11: ansible-core

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_11.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_11.rst
@@ -1,7 +1,7 @@
-.. _base_roadmap_2_11:
+.. _core_roadmap_2_11:
 
 =================
-Ansible-base 2.11
+Ansible-core 2.11
 =================
 
 .. contents::
@@ -13,21 +13,21 @@ Release Schedule
 Expected
 ========
 
-PRs must be raised well in advance of the dates below to have a chance of being included in this ansible-base release.
+PRs must be raised well in advance of the dates below to have a chance of being included in this ansible-core release.
 
 .. note:: There is no Alpha phase in 2.11.
 .. note:: Dates subject to change.
 
-- 2021-02-12 Feature Freeze
+- 2021-02-12 ansible-core Feature Freeze
   No new functionality (including modules/plugins) to any code
 
-- 2021-03-02 Beta 1
-- ????-??-?? Beta 2
+- 2021-03-02 ansible-core Beta 1
+- ????-??-?? ansible-core Beta 2
 
-- 2021-03-29 Release Candidate 1
-- ????-??-?? Release Candidate 2
+- 2021-03-29 ansible-core Release Candidate 1
+- ????-??-?? ansible-core Release Candidate 2
 
-- 2021-04-26 Release
+- 2021-04-26 ansible-core Release
 
 Release Manager
 ---------------
@@ -40,8 +40,9 @@ Planned work
 - Improve UX of ``ansible-galaxy collection`` CLI, specifically as it relates to install and upgrade.
 - Add new Role Argument Spec feature that will allow a role to define an argument spec to be used in
   validating variables used by the role.
+- repackaged as ``ansible-core``
 - Bump the minimum Python version requirement for the controller to Python 3.8. There will be no breaking changes
-  to this release, however ``ansible-base`` will only be packaged for Python 3.8+. ``ansible-base==2.12`` will include
+  to this release, however ``ansible-core`` will only be packaged for Python 3.8+. ``ansible-core==2.12`` will include
   breaking changes requiring at least Python 3.8.
 - Introduce split-controller testing in ``ansible-test`` to separate dependencies for the controller from
   dependencies on the target.


### PR DESCRIPTION
##### SUMMARY
Make the roadmap clearer that we are talking about `ansible-core`
https://github.com/ansible/ansible/pull/72594

Hopefully, reduce confusion between `ansible` and `ansible-core`

##### ISSUE TYPE
- Docs Pull Request

